### PR TITLE
Prepends shareddocuments scheme to file paths (#65)

### DIFF
--- a/Sources/RevealFile/RevealFileCoordinator.swift
+++ b/Sources/RevealFile/RevealFileCoordinator.swift
@@ -49,7 +49,8 @@ final class RevealFileCoordinator: Coordinator {
             with: ""
         )
         #else
-        UIApplication.shared.open(jotFileInfo.url)
+        let revealFileURL = RevealFileURL(jotFileInfo: jotFileInfo)
+        UIApplication.shared.open(revealFileURL.toURL())
         #endif
     }
 }

--- a/Sources/RevealFile/RevealFileURL.swift
+++ b/Sources/RevealFile/RevealFileURL.swift
@@ -1,0 +1,27 @@
+/*
+ Jottre: Minimalistic jotting for iPhone, iPad and Mac.
+ Copyright (C) 2021-2026 Anton Lorani
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+struct RevealFileURL: URLConvertible {
+    let scheme: String? = "shareddocuments"
+    let host: String? = ""
+    let path: String
+
+    init(jotFileInfo: JotFile.Info) {
+        path = jotFileInfo.url.path
+    }
+}


### PR DESCRIPTION
* After the migration from url navigation for RevealFileCoordinator, the shareddocuments scheme got lost.